### PR TITLE
fix: Corrijo y redondeo resultado de precio

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,7 @@ class TaxCalculator {
   async getDollarValueFromApi() {
     const response = await fetch("https://dolarapi.com/v1/dolares/tarjeta");
     const data = await response.json();
-    return parseInt(data.venta);
+    return parseFloat(data.venta).toFixed(2);
   }
 
   /**
@@ -61,7 +61,7 @@ class TaxCalculator {
       document.querySelector(".costEntry").value.replace(/,/g, ".")
     );
 
-    return inputValueWithoutComma * dollarValue * this.taxAmount;
+    return parseFloat(inputValueWithoutComma * dollarValue * this.taxAmount).toFixed(2);
   }
 
   /**

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         </h1>
       </div>
       <div class="info__description">
-        <div class="more-info">
+        <div class="more-info"></div>
           <b class="highlightedPhrase">Noticia importante</b>
           <p>
             A partir del 20 de noviembre de 2023, Steam ha anunciado que los precios y carteras de Argentina, se convertirán a USD:
@@ -77,7 +77,7 @@
           <li>Percepción de Ganancias: 45%</li>
           <li>Impuesto PAIS: 30%</li>
           <li>Percepción de bienes personales: 25%</li>
-        </ul> -->
+        </ul> -->ss
         <b class="highlightedPhrase">Cotización</b>
         <p class="white">
           La aplicación funciona gracias a DolarAPI, la cual nos brinda datos actualizados respecto a las diferentes cotizaciones del dólar. Si querés saber más, ingresá al enlace de abajo:


### PR DESCRIPTION
En este PR se agrega el redondeo del precio final de un producto en Steam. 

Antes, al insertar un precio como: '2,321000',
Se obtenía algo como '1830,938295738'

Demasiados decimales. Esto causaba que la aplicación pierda su estructura visual. 

Por eso se agrega un `parseFloat(x).toFixed(2)` a ambos, tanto el fetch de DolarAPI, tanto como el resultado calculado.